### PR TITLE
fix: remove log that would spam the console "Client attempted to conn…

### DIFF
--- a/src/main/java/com/sekwah/narutomod/network/PacketHandler.java
+++ b/src/main/java/com/sekwah/narutomod/network/PacketHandler.java
@@ -30,7 +30,6 @@ public class PacketHandler {
                 if (version.equals(PROTOCOL_VERSION)) {
                     return true;
                 } else {
-                    LOGGER.error("Client attempted to connect with a different version of the mod. Client Version: " + PROTOCOL_VERSION + " Server Version: " + version);
                     return false;
                 }
             })
@@ -38,7 +37,6 @@ public class PacketHandler {
                 if (version.equals(PROTOCOL_VERSION)) {
                     return true;
                 } else {
-                    LOGGER.error("Client attempted to connect with a different version of the mod. Server Version: " + PROTOCOL_VERSION + " Client Version: " + version);
                     return false;
                 }
             })


### PR DESCRIPTION
…ect"

This was caused because forge rebakes the status every 5 seconds as well as neoforge now has a proper UI to tell users what is up now.